### PR TITLE
Changes for rearranging PETlistmodes + for Nifti conversion of Diffusion files

### DIFF
--- a/Cenir_DB.py
+++ b/Cenir_DB.py
@@ -136,7 +136,7 @@ class Cenir_DB:
         """
         
 #        con,cur = self.open_sql_connection_lixum()
-        con,cur = self.open_sql_connection()
+        con,cur = self.open_sql_connection_lixum()
         cur2 = con.cursor()
 #        con = mdb.connect(host = 'mysql.lixium.fr', user = 'cenir', passwd =  'y0p4l4sql', db = 'cenir')
 #        cur = con.cursor(mdb.cursors.DictCursor)

--- a/Exam_info.py
+++ b/Exam_info.py
@@ -558,8 +558,11 @@ class Exam_info:
 #            if p1.has_key(0x051100a):
 #                dicinfo["Duration"] = self.get_series_duration_from_siemens_tag(p1[0x051100a].value)            
         if p1.has_key(0x051100a):
-            dicinfo["Duration2"] = self.get_series_duration_from_siemens_tag(p1[0x051100a].value)            
-        
+            try:
+                
+                dicinfo["Duration2"] = self.get_series_duration_from_siemens_tag(p1[0x051100a].value)            
+            except: 
+                pass
         if [0x19,0x105a] in p1:
             
             dicinfo["Duration"]  = p1[0x19,0x105a].value/1000000
@@ -1561,9 +1564,9 @@ class Exam_info:
                                         os.makedirs(dirlist)
                                         shutil.copy2(flistin,foutlist)
                                 except:
-                                    pass
+                                    print 'Tried to copy PETlistfile without success'
                         except:
-                            print 'Tried to copy PETlistfile without success'
+                            pass
                             
                         
                         shutil.copy2(fin,fout)

--- a/Exam_info.py
+++ b/Exam_info.py
@@ -761,6 +761,7 @@ class Exam_info:
 #                self.log.warning("INVALIDE STACK could not add volume %s because %s ",vol[2],detail)
 
             try:
+                #all_stack.append(my_stack.to_nifti(voxel_order='', embed_meta=True))
                 all_stack.append(my_stack.to_nifti(voxel_order='LAS', embed_meta=True))
 #how to make it basic this doeas not works                all_stack.append(my_stack.to_nifti(voxel_order='', embed_meta=True))
             
@@ -1114,7 +1115,13 @@ class Exam_info:
 	    rot = np.dot(np.diag([-1, -1 ,1]),rotnii)
 	
 	#dicom orientation	
-	patorient = nw.get_meta('ImageOrientationPatient')	
+ 
+	patorient = nw.get_meta('ImageOrientationPatient')
+     # For GE Oblique sequence more than one ImageOrientation (but all very close)     
+	if patorient is None:
+         patorient = nw.get_meta('ImageOrientationPatient',(0,0,0,0))
+      
+
 	patorient = np.reshape(patorient, (2, 3)).T
 	rotations = np.eye(3)
 	rotations[:, :2] = patorient
@@ -1122,8 +1129,13 @@ class Exam_info:
 	# TODO it may not always be the cross-product ... genral case should look at each slices
 	rotations[:, 2] = np.cross(patorient[:, 0], patorient[:, 1])
 	#rotations = np.dot(rotnii,rotations) ca marche pas !!! pour GE il manque -1 sur x et pour siemens -1 sur y arggg
+         #pour GE ne pas appliquer la rotation aux bvecs car deja dans le repere de la boite
+        if 'GE MEDICAL SYSTEMS' in nw.get_meta("Manufacturer"):
+            bvecnew=bvec
+        else:
+            bvecnew = np.dot(bv,rot)
 
-        bvecnew = np.dot(bv,rot)
+        
 	bvecnew_dic = np.dot(bv,rotations)
         out_path = os.path.join(dest_dir, 'diffusion_dir.bvecs')        
         out_path_dic = os.path.join(dest_dir, 'diffusion_dir.dicom_vec')        
@@ -1475,9 +1487,9 @@ class Exam_info:
             if nb_of_dic_file>0:
                 self.log.info('Reading %d file in %s',len(alldic),dir_path)                                
 #                self.log.info('MEM2 %0.0f M ',p.get_memory_info().rss/1024/1024)
+                #We got rid of the 'ProtocolName' in group_keys for the formation of stacks as it created problems with GE files
+                group_keys =  ('SeriesInstanceUID','SeriesNumber')
                 
-                group_keys =  ('SeriesInstanceUID','SeriesNumber','ProtocolName')
-            
                 pg,dicom_file_size,n_ommited  = self.get_group_stack_from_dic(alldic,group_keys=group_keys)
                 
 #                self.log.info('MEM3 %0.0f M ',p.get_memory_info().rss/1024/1024)
@@ -1486,7 +1498,6 @@ class Exam_info:
                     vol = v[0]
                     (exa,suj,ser) = self.get_exam_suj_ser_from_dicom_meta(vol[1])
                     dest_dir = os.path.join(self.dicom_dir,exa,suj,ser)
-                    
                     if os.path.isdir(dest_dir):
                         dest_dir =  os.path.join(self.dicom_doublon,exa,suj,ser)
                         
@@ -1530,24 +1541,27 @@ class Exam_info:
                                 # Mettre l'arborescence correspondant au fichier LIST (PESI/pXX/eXX/sXX/GEMS PET LSTDC pour pouvoir les remettres sur la machine)        
                                 path=os.path.dirname(fout)
                                 fin2=fin[fin.rfind('PESI'):]
-                                try:
-                                    
-                                    flist=vol[0][0x09,0x10da].value
-                                except:
-                                    pass
-                                flistin=fin[:fin.rfind('PESI')]+flist
-                                
                                 fout=os.path.join(path,fin2)
-                                foutlist=path+flist
                                 dirGEMS=os.path.dirname(fout)
                                 
                                 if not os.path.isdir(dirGEMS):
                                     os.makedirs(dirGEMS)
+                                try:
                                     
-                                if not os.path.isfile(foutlist):
-                                    dirlist=os.path.dirname(foutlist)
-                                    os.makedirs(dirlist)
-                                    shutil.copy2(flistin,foutlist)
+                                    flist=vol[0][0x09,0x10da].value
+                                
+                                    flistin=fin[:fin.rfind('PESI')]+flist
+                                
+                                
+                                    foutlist=path+flist
+                                    
+                                    
+                                    if not os.path.isfile(foutlist):
+                                        dirlist=os.path.dirname(foutlist)
+                                        os.makedirs(dirlist)
+                                        shutil.copy2(flistin,foutlist)
+                                except:
+                                    pass
                         except:
                             print 'Tried to copy PETlistfile without success'
                             

--- a/do_common.py
+++ b/do_common.py
@@ -239,7 +239,7 @@ def alpha_num_str(stri):
         return stri
         
     if type(stri) is not unicode:
-        stri = extract.make_unicode(stri)
+        stri = make_unicode(stri)
     
 #    if type(stri) is str:
 #        stri=stri.replace('\xe9','e')
@@ -259,7 +259,7 @@ def alpha_num_str(stri):
     #correspond au caractere a chapeau
     stri=stri.replace(u'\xe2','a')
     #correspond au caractere a chapeau
-    stri=stri.replace( extract.make_unicode('/'), '_')
+    stri=stri.replace(make_unicode('/'), '_')
     #convert to string and ignore other strange caractere
     stri=stri.encode('utf-8').decode('ascii','ignore')
     stri = str(stri)
@@ -287,7 +287,7 @@ def alpha_num_str_min(stri):
 #    import re
     
     if type(stri) is not unicode:
-        stri = extract.make_unicode(stri)
+        stri = make_unicode(stri)
     
 #    if type(stri) is str:
 #        stri=stri.replace('\xe9','e')
@@ -323,6 +323,20 @@ def alpha_num_str_min(stri):
     
     
     return stri 
+
+def make_unicode(in_str):
+    '''Try to convetrt in_str to unicode'''
+    for encoding in ('utf8', 'latin1'):
+        try:
+            result = unicode(in_str, encoding=encoding)
+        except UnicodeDecodeError:
+            pass
+        else:
+            break
+    else:
+        raise ValueError("Unable to determine string encoding: %s" % in_str)
+    return result
+    
 
 #plu efficace
 #def sanitize_path_comp(path_comp):


### PR DESCRIPTION
Changes for bugfix for rearranging PETlistmodes due to dcmstack update +
 for Nifti conversion of Diffusion files (works in Axial for now and waiting for answers from dcmstack for writing niftis in sagittal and oblique)

Attention pour la partie make_unicode rajouter à do_common car ils l'ont enlever de extract.py (dans l'update dcmstack). 
